### PR TITLE
add default user agent to HTMLFetcher

### DIFF
--- a/boilerpipe-common/src/main/java/com/kohlschutter/boilerpipe/sax/HTMLFetcher.java
+++ b/boilerpipe-common/src/main/java/com/kohlschutter/boilerpipe/sax/HTMLFetcher.java
@@ -45,7 +45,10 @@ public class HTMLFetcher {
    * @throws IOException
    */
   public static HTMLDocument fetch(final URL url) throws IOException {
+
     final URLConnection conn = url.openConnection();
+    conn.setRequestProperty("User-Agent", "Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0");
+
     final String ct = conn.getContentType();
 
     if (ct == null || !(ct.equals("text/html") || ct.startsWith("text/html;"))) {


### PR DESCRIPTION
HTMLFetcher doesn't have a user agent thus ArticleExtractor fails a lot of the time with 403's. This sets a default agent to firefox on linux.
