### PR TITLE
Fix bad package name in the sax's package imports

### DIFF
--- a/boilerpipe-common/src/main/java/com/kohlschutter/boilerpipe/sax/BoilerpipeHTMLParser.java
+++ b/boilerpipe-common/src/main/java/com/kohlschutter/boilerpipe/sax/BoilerpipeHTMLParser.java
@@ -22,7 +22,7 @@ import org.apache.xerces.parsers.AbstractSAXParser;
 import com.kohlschutter.boilerpipe.BoilerpipeDocumentSource;
 import com.kohlschutter.boilerpipe.document.TextBlock;
 import com.kohlschutter.boilerpipe.document.TextDocument;
-import com.kohlschutter.boilerpipe.org.cyberneko.html.HTMLConfiguration;
+import org.cyberneko.html.HTMLConfiguration;
 
 /**
  * A simple SAX Parser, used by {@link BoilerpipeSAXInput}. The parser uses <a

--- a/boilerpipe-common/src/main/java/com/kohlschutter/boilerpipe/sax/HTMLHighlighter.java
+++ b/boilerpipe-common/src/main/java/com/kohlschutter/boilerpipe/sax/HTMLHighlighter.java
@@ -38,7 +38,7 @@ import com.kohlschutter.boilerpipe.BoilerpipeExtractor;
 import com.kohlschutter.boilerpipe.BoilerpipeProcessingException;
 import com.kohlschutter.boilerpipe.document.TextBlock;
 import com.kohlschutter.boilerpipe.document.TextDocument;
-import com.kohlschutter.boilerpipe.org.cyberneko.html.HTMLConfiguration;
+import org.cyberneko.html.HTMLConfiguration;
 
 /**
  * Highlights text blocks in an HTML document that have been marked as "content" in the

--- a/boilerpipe-common/src/main/java/com/kohlschutter/boilerpipe/sax/ImageExtractor.java
+++ b/boilerpipe-common/src/main/java/com/kohlschutter/boilerpipe/sax/ImageExtractor.java
@@ -38,7 +38,7 @@ import com.kohlschutter.boilerpipe.BoilerpipeProcessingException;
 import com.kohlschutter.boilerpipe.document.Image;
 import com.kohlschutter.boilerpipe.document.TextBlock;
 import com.kohlschutter.boilerpipe.document.TextDocument;
-import com.kohlschutter.boilerpipe.org.cyberneko.html.HTMLConfiguration;
+import org.cyberneko.html.HTMLConfiguration;
 
 /**
  * Extracts the images that are enclosed by extracted content.


### PR DESCRIPTION
Some classes are importing "com.kohlschutter.boilerpipe.org.cyberneko.html.HTMLConfiguration" instead of "org.cyberneko.html.HTMLConfiguration"